### PR TITLE
Removido a união através do Extract em date

### DIFF
--- a/src/components/Form/InputDate/index.tsx
+++ b/src/components/Form/InputDate/index.tsx
@@ -1,4 +1,4 @@
-import { Calendar as CalendarPrime, CalendarProps } from "primereact/calendar";
+import { Calendar as CalendarPrime } from "primereact/calendar";
 import { classNames } from "primereact/utils";
 import React from "react";
 import {
@@ -23,7 +23,7 @@ interface IProps<T extends FieldValues> {
   showTime?: boolean;
   timeOnly?: boolean;
   hourFormat?: "24" | "12";
-  selectionMode?: Extract<CalendarProps, 'selectionMode'>;
+  selectionMode?: "single" | "multiple" | "range"
   readOnlyInput?: boolean;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,12 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
+    "target": "ES6",
     "module": "CommonJS",
-    "lib": ["dom", "dom.iterable", "ESNext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "ES6"
+    ],
     "jsx": "react",
     "outDir": "./build",
     "sourceMap": true,
@@ -20,7 +24,9 @@
     "allowSyntheticDefaultImports": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": [
+    "src"
+  ],
   "exclude": [
     "node_modules",
     "src/setupTests.js",


### PR DESCRIPTION
### Descrição

A utilização do utilitário de tipos Extract foi removido devido a um bug de build que resultava na falha de inferência de tipos em ambientes de desenvolvimento.

### Observações

Os tipos que eram extraídos de CalendarProps são definidos explicitamente